### PR TITLE
Fix OpenAI gem reference

### DIFF
--- a/rails_vite_template.rb
+++ b/rails_vite_template.rb
@@ -51,7 +51,7 @@ inject_into_file "Gemfile", before: "group :development, :test do" do
     gem "paper_trail"
     gem "sidekiq"
     gem "redis"
-    gem "openai", "~> 5.2"
+    gem "ruby-openai", "~> 5.2"
     gem "aasm"
     gem "acts_as_tenant"
     gem "rack-attack"


### PR DESCRIPTION
## Summary
- update the template Gemfile injection to reference the correct ruby-openai gem so bundler can resolve it

## Testing
- rails new tmp_app -d postgresql --css tailwind -m ./rails_template/rails_vite_template.rb *(fails: missing `rails` executable in environment; `gem install rails` returns HTTP 403 when fetching from rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d1bba1114c83229eddabe3b552a3b9